### PR TITLE
Update to fix maven compile error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
   <properties>
     <jetty.version>9.4.10.v20180503</jetty.version>
     <shade.version>3.1.0</shade.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
I got the error "Source option 5 is no longer supported. Use 7 or later." when trying to do "mvn package". Adding compiler source and target versions solved this issue. It is currently set to compile for Java 8 ("1.8"), but Java 11 ("1.11") also works.